### PR TITLE
A one-char change

### DIFF
--- a/instagiffer.py
+++ b/instagiffer.py
@@ -2409,7 +2409,7 @@ class AnimatedGif:
             captionTweakX[0]=-1
 
         if fontOutlineThickness >= 1:
-            cmdProcImage += " -stroke %s -strokewidth %d -annotate %+d%+d \"%s\" %s "  % (fontOuterColor, fontOutlineThickness, positionAdjX+captionTweakX[0], positionAdjY+captionTweakY[0], captionText, outlineBlur)
+            cmdProcImage += " -stroke %s -strokewidth %d -annotate %+d%+d \"%s\" %s "  % (fontOuterColor, fontOutlineThickness, positionAdjX+captionTweakX[1], positionAdjY+captionTweakY[0], captionText, outlineBlur)
             cmdProcImage += " -stroke %s -strokewidth %d -annotate %+d%+d \"%s\" %s "  % (fontOuterColor, fontOutlineThickness, positionAdjX+captionTweakX[1], positionAdjY+captionTweakY[1], captionText, outlineBlur)
 
         cmdProcImage += " -stroke none  -strokewidth %d -fill %s -annotate %+d%+d \"%s\" %s " % (fontOutlineThickness, fontColor, positionAdjX, positionAdjY, captionText, fontBlur)


### PR DESCRIPTION
changing the X coordinate for one of the convert stroke commands, to make sure that the two-pass stroke 'logic' doesnt accidentally create a gross drop shadow instead of a proper stroke.